### PR TITLE
[Enabler281] use new syntax for set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,17 +47,17 @@ runs:
         case ${REFERENCE} in
           # tags that start with v and have rc in the name
           refs/tags/v*rc*)
-            echo "::set-output name=name::${PREFIX}${{ inputs.suffix-release-candidate }}"
+            echo "name=${PREFIX}${{ inputs.suffix-release-candidate }}" >> $GITHUB_OUTPUT
             ;;
 
           # tags that start with v and aren't including rc
           refs/tags/v*)
-            echo "::set-output name=name::${PREFIX}${{ inputs.suffix-release }}"
+            echo "name=${PREFIX}${{ inputs.suffix-release }}" >> $GITHUB_OUTPUT
            ;;
 
-          # everything else gets is a devlopment version
+          # everything else gets is a development version
           *)
-            echo "::set-output name=name::${PREFIX}${{ inputs.suffix-default }}"
+            echo "name=${PREFIX}${{ inputs.suffix-default }}" >> $GITHUB_OUTPUT
             ;;
 
           esac


### PR DESCRIPTION
This PR switch the `set-ouput` syntax to the preferred `$GITHUB_OUTPUT` method as shown in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

To test:

1. install `act` following the instruction in Readme.
2. run `act` at the root of the repo.
3. run `act -v` again, and check the terminal to ensure the updated syntax is reflected in the console output.

> IBM item: https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=281